### PR TITLE
Tf.keras tf2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# models
+edgel3_*.h5
+
+# mac
+.DS_Store
+
+# trash
+shh/
+shhh/
+shhhh/
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/edgel3/core.py
+++ b/edgel3/core.py
@@ -6,7 +6,7 @@ import soundfile as sf
 import numpy as np
 from numbers import Real
 import warnings
-import keras
+import tensorflow as tf
 from edgel3.models import load_embedding_model
 from edgel3.edgel3_exceptions import EdgeL3Error
 from edgel3.edgel3_warnings import EdgeL3Warning
@@ -15,7 +15,7 @@ from edgel3.edgel3_warnings import EdgeL3Warning
 TARGET_SR = 48000
 
 
-def _center_audio(audio, frame_len):    
+def _center_audio(audio, frame_len):
     """Center audio so that first sample will occur in the middle of the first frame"""
     return np.pad(audio, (int(frame_len / 2.0), 0), mode='constant', constant_values=0)
 
@@ -34,7 +34,7 @@ def _pad_audio(audio, frame_len, hop_len):
 
     return audio
 
-def get_embedding(audio, sr, model=None, retrain_type='ft', sparsity=95.45, center=True, hop_size=0.1, verbose=1):    
+def get_embedding(audio, sr, model=None, retrain_type='ft', sparsity=95.45, center=True, hop_size=0.1, verbose=1):
     """Computes and returns L3 embedding for an audio data from pruned audio model.
 
     Parameters
@@ -75,8 +75,8 @@ def get_embedding(audio, sr, model=None, retrain_type='ft', sparsity=95.45, cent
     if np.all(audio == 0):
         warnings.warn('Provided audio is all zeros', EdgeL3Warning)
 
-    if model is not None and not isinstance(model, keras.models.Model):
-        raise EdgeL3Error('Invalid model provided. Must be of type keras.model.Models'
+    if model is not None and not isinstance(model, tf.keras.Model):
+        raise EdgeL3Error('Invalid model provided. Must be of type tf.keras.Models'
                           ' but got {}'.format(str(type(model))))
 
     if retrain_type not in ('ft', 'kd'):
@@ -142,7 +142,7 @@ def get_embedding(audio, sr, model=None, retrain_type='ft', sparsity=95.45, cent
     return embedding, ts
 
 
-def process_file(filepath, output_dir=None, suffix=None, model=None, sparsity=95.45, center=True, hop_size=0.1, verbose=True):    
+def process_file(filepath, output_dir=None, suffix=None, model=None, sparsity=95.45, center=True, hop_size=0.1, verbose=True):
     """Computes and saves L3 embedding for given audio file
 
     Parameters
@@ -192,7 +192,7 @@ def process_file(filepath, output_dir=None, suffix=None, model=None, sparsity=95
     assert os.path.exists(output_path)
 
 
-def get_output_path(filepath, suffix, output_dir=None):    
+def get_output_path(filepath, suffix, output_dir=None):
     """
 
     Parameters
@@ -203,7 +203,7 @@ def get_output_path(filepath, suffix, output_dir=None):
         String to append to filename (including extension)
     output_dir : str or None
         Path to directory where file will be saved. If None, will use directory of given filepath.
-    
+
     Returns
     -------
     output_path : str

--- a/edgel3/core.py
+++ b/edgel3/core.py
@@ -43,7 +43,7 @@ def get_embedding(audio, sr, model=None, retrain_type='ft', sparsity=95.45, cent
         1D numpy array of audio data.
     sr : int
         Sampling rate, if not 48kHz will audio will be resampled.
-    model : keras.models.Model or None
+    model : tf.keras.Model or None
         Loaded model object. If a model is provided, then `sparsity` will be ignored.
         If None is provided, the model will be loaded using
         the provided `sparsity` value.
@@ -155,7 +155,7 @@ def process_file(filepath, output_dir=None, suffix=None, model=None, sparsity=95
     suffix : str or None
         String to be appended to the output filename, i.e. <base filename>_<suffix>.npz.
         If None, then no suffix will be added, i.e. <base filename>.npz.
-    model : keras.models.Model or None
+    model : tf.keras.Model or None
         Loaded model object. If a model is provided, then `sparsity` will be ignored.
         If None is provided, the model will be loaded using the given `sparsity`.
     sparsity : {95.45, 53.5, 63.5, 72.3, 73.5, 81.0, 87.0, 90.5}

--- a/edgel3/models.py
+++ b/edgel3/models.py
@@ -6,12 +6,12 @@ with warnings.catch_warnings():
     # Suppress TF and Keras warnings when importing
     warnings.simplefilter("ignore")
     from kapre.time_frequency import Spectrogram, Melspectrogram
-    from keras.layers import (
-        Input, Conv2D, BatchNormalization, MaxPooling2D,
-        Flatten, Activation, Lambda
-    )
-    from keras.models import Model
-    import keras.regularizers as regularizers
+    import tensorflow as tf
+    from tensorflow.keras import Model, Input
+    from tensorflow.keras.layers import (
+        Conv2D, BatchNormalization, MaxPooling2D,
+        Flatten, Activation)
+    import tensorflow.keras.regularizers as regularizers
 
 
 def load_embedding_model(retrain_type, sparsity):
@@ -22,14 +22,14 @@ def load_embedding_model(retrain_type, sparsity):
     Parameters
     ----------
     retrain_type: 'ft' or 'kd'
-        Type of retraining for the sparsified weights of L3 audio model. 'ft' chooses the fine-tuning method 
-        and 'kd' returns knowledge distilled model. 
+        Type of retraining for the sparsified weights of L3 audio model. 'ft' chooses the fine-tuning method
+        and 'kd' returns knowledge distilled model.
     sparsity: {95.45, 53.5, 63.5, 72.3, 73.5, 81.0, 87.0, 90.5}
         The desired sparsity of audio model.
 
     Returns
     -------
-    model : keras.models.Model
+    model : tensorflow.keras.Model
         Model object.
 
     """
@@ -55,8 +55,8 @@ def load_embedding_model_path(retrain_type, sparsity):
     Parameters
     ----------
     retrain_type: 'ft' or 'kd'
-        Type of retraining for the sparsified weights of L3 audio model. 'ft' chooses the fine-tuning method 
-        and 'kd' returns knowledge distilled model. 
+        Type of retraining for the sparsified weights of L3 audio model. 'ft' chooses the fine-tuning method
+        and 'kd' returns knowledge distilled model.
     sparsity : {95.45, 53.5, 63.5, 72.3, 73.5, 81.0, 87.0, 90.5}
         Desired sparsity of the audio model.
 
@@ -77,7 +77,7 @@ def _construct_sparsified_audio_network():
 
     Returns
     -------
-    model : keras.models.Model
+    model : tensorflow.keras.Model
         Model object.
 
     """
@@ -168,4 +168,3 @@ def _construct_sparsified_audio_network():
 MODELS = {
     'sparsified': _construct_sparsified_audio_network
 }
-

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,7 @@ setup(
     install_requires=[
         'numpy>=1.13.0',
         'scipy>=0.19.1',
-        'kapre>=0.1.4',
-        'keras>=2.0.9',
+        'kapre>=0.1.7',
         'PySoundFile>=0.9.0.post1',
         'resampy>=0.2.1,<0.3.0',
         'h5py>=2.7.0,<3.0.0',


### PR DESCRIPTION
summary of changes:
 - converted from `keras` to `tf.keras` (tensorflow 2)
 - upgraded `kapre` to `0.1.7` which uses `tf.keras`
 - added a python `.gitignore`
 - factored out the common `conv2d` parameters (I can roll this commit back if you want)