### PR TITLE
Pinning Kapre to 0.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     install_requires=[
         'numpy>=1.13.0',
         'scipy>=0.19.1',
-        'kapre>=0.1.4',
+        'kapre==0.1.4',
         'keras>=2.0.9',
         'PySoundFile>=0.9.0.post1',
         'resampy>=0.2.1,<0.3.0',


### PR DESCRIPTION
@ksangeeta2429 Just like OpenL3, the EdgeL3 package is not compatible with the newer version of Kapre (1.7). And while the package can still be installed successfully via `pip install edgel3` it is unusable, (i.e. calls to `edgel3.get_embedding` or `edgel3.models.load_embedding_model` error out).

The Kapre version should be pinned to `kapre==1.4`, just like OpenL3 (see commit [here](https://github.com/marl/openl3/commit/a6ac4ef583ed0d7a0ca4b59cb1074f5d74aabc37#diff-2eeaed663bd0d25b7e608891384b7298)

You can check out the below Colab Notebooks for examples of the package failing with `kapre==1.7 `and working with `kapre==1.4`

- [Kapre 1.4 (working)](https://colab.research.google.com/drive/1pIYjevvBRjGBRDaC2pbzDZqwo64h9-xR?usp=sharing)
- [Kapre 1.7 (broken)](https://colab.research.google.com/drive/1Nobbd3aUnGEagwodo2GSM1qnmJ49EyM1?usp=sharing)


Resolves #4 

